### PR TITLE
Fixed ProductTile default propery validation issue

### DIFF
--- a/components/core/ProductTile.vue
+++ b/components/core/ProductTile.vue
@@ -77,7 +77,7 @@ export default {
   props: {
     labelsActive: {
       type: Boolean,
-      requred: false,
+      required: false,
       default: true
     },
     onlyImage: {


### PR DESCRIPTION
Fixed the validation default property issue for the `labelsActive` in ProductTile.vue

**Before:**
![image](https://user-images.githubusercontent.com/9442993/58548438-f27a9a00-8226-11e9-8c50-5b50864026e0.png)


**After:**
![image](https://user-images.githubusercontent.com/9442993/58548426-e8589b80-8226-11e9-87b4-94a83d2612bb.png)
