### PR TITLE
Bugfix/cart minibar qty edit

### DIFF
--- a/components/core/ProductTile.vue
+++ b/components/core/ProductTile.vue
@@ -77,7 +77,7 @@ export default {
   props: {
     labelsActive: {
       type: Boolean,
-      requred: false,
+      required: false,
       default: true
     },
     onlyImage: {

--- a/components/core/blocks/Microcart/Product.vue
+++ b/components/core/blocks/Microcart/Product.vue
@@ -59,7 +59,7 @@
           </span>
           <div v-show="isEditing" class="inline-flex">
             <qty-input
-              v-model.number="qty"
+              v-model.number="product.qty"
               :id="'qty-' + product.sku"
               data-testid="productQtyInput"
               size="sm" />


### PR DESCRIPTION
**Issue:**
We can't able to edit qty in cart sidebar due to having an issue of qty pass

**Before:**
![image](https://user-images.githubusercontent.com/9442993/58961474-d480dc80-87c6-11e9-9e98-0f6b83c00cf6.png)
